### PR TITLE
Removed expired discord link

### DIFF
--- a/src/pages/faucet/index.js
+++ b/src/pages/faucet/index.js
@@ -53,7 +53,7 @@ const ApplyFunds = function ({ dispatch, loading }) {
       icon: join_discord,
       title: _t('join.discord'),
       des: _t('join.discord.des'),
-      link: 'https://discord.gg/sp79pa',
+      link: 'https://discord.com/invite/2tWtHDm',
       recommend: true,
     },
     {


### PR DESCRIPTION
Current Discord link points to an expired dirscord invide link.
updated with the current KuChain Community Discord link.

Expired discord links can be taken over through vanity addresses, where a malicious user could create a discord invite link using the same expired link and make it point to a seperate Discord channel. A seperate Discord channel could be used to scam users by pretending the be the real KuChain Community channel.  Please see similar BugCrowd report here: https://bugcrowd.com/disclosures/40a60d98-cc7d-40eb-9e5b-87632875f055/discord-link-expired-possible-vanity-address-could-be-used-to-link-a-malicious-discord-server